### PR TITLE
Create new PhotoWindow if the clicked image belongs to a different ph…

### DIFF
--- a/code/MouseClick.py
+++ b/code/MouseClick.py
@@ -78,6 +78,7 @@ class MouseClick(QgsMapTool):
                     ########## SHOW PHOTOS ############
                     feature = selected_features[0]
                     self.drawSelf.featureIndex = feature.id()
+                    activeLayerChanged =  not hasattr(self.drawSelf, 'layerActive') or (self.drawSelf.layerActive != layer)
                     self.drawSelf.layerActive = layer
                     self.drawSelf.fields = fields
                     self.drawSelf.maxlen = len(self.drawSelf.layerActive.name())
@@ -109,8 +110,7 @@ class MouseClick(QgsMapTool):
 
                     self.drawSelf.getImage = QImage(imPath)
 
-                    # sigeal : create new photo viewer if it doesn't exist
-                    if self.photosDLG == None:
+                    if self.photosDLG is None or activeLayerChanged:
                         self.photosDLG = PhotoWindow(self.drawSelf)
                     self.photosDLG.viewer.scene.clear()
                     pixmap = QPixmap.fromImage(self.drawSelf.getImage)


### PR DESCRIPTION
Soimetimes we have several photo layers in a QGIS project. If using the click-photo tool on a feature of layer A and later on a feature with layer B, the photo window shows photos of layerA when clicking the right/left arrow on the picture. The only possibility to see the other features of layerB seems to be to restart QGIS and then click a feature of layerB first.

This is probably because the photo dialog is not re-created each time. This PR changes the behaviour to re-create the photo dialog if the active layer has been changed, therefore showing the images of the current photo layer when selecting the left/right arrow buttons 