### PR TITLE
Sort points by filename

### DIFF
--- a/ImportPhotos.py
+++ b/ImportPhotos.py
@@ -548,7 +548,7 @@ class ImportPhotos:
             pass
 
         pictures_to_remove = list(set(picture_paths) - set(list_pictures))
-        pictures_to_add = list(set(list_pictures) - set(picture_paths))
+        pictures_to_add = list(set(list_pictures) - set(picture_paths)).sorted()
 
         editing_started = self.selected_layer.startEditing()
         if editing_started:


### PR DESCRIPTION
**Overview**
This pull request introduces a new feature to the ImportPhotos QGIS plugin that sorts generated points based on the filenames of the photos. This enhancement aligns with the common file naming conventions where photo files are named in the same order as the datetime when the photo was shot. By sorting points according to the filename, the fid (Feature ID) will be generated in a sorted manner.

**Issue**
Currently, points generated by the plugin is not sorted in any specific order. This is becuase the file list is converted to set and thus loses order.

**Motivation**
The motivation behind this feature is to facilitate easier and more efficient data manipulation and visualization within QGIS. A sorted fid can be utilized in various ways, significantly simplifying several GIS tasks. For instance, adding arrows to connect adjacent points by ID becomes much easier when the points are pre-sorted. This feature eliminates the need for additional steps to sort points by other criteria before drawing connections between them.