### PR TITLE
Fixed relative path handling in PhotoWindow and ImportPhotos.

### DIFF
--- a/ImportPhotos.py
+++ b/ImportPhotos.py
@@ -24,6 +24,7 @@ from qgis.PyQt.QtGui import QIcon, QGuiApplication
 from qgis.PyQt import uic
 from qgis.PyQt.QtWidgets import QDialog
 from qgis.PyQt.QtCore import QSettings, QTranslator, QCoreApplication, Qt, QTextCodec
+from qgis.PyQt.QtCore import QFileInfo
 from qgis.core import *
 from qgis.gui import QgsRuleBasedRendererWidget
 
@@ -316,6 +317,17 @@ class ImportPhotos:
             else:
                 # Set extension with the specified filter
                 self.dlg.out.setText(os.path.splitext(outputPath)[0] + extension)
+    
+    def get_path_relative_to_project_root(self, abs_path):
+        project_folder = QFileInfo(
+            self.project_instance.fileName()).absolutePath()
+        try:
+            rel_path = os.path.relpath(
+                path=os.path.normpath(abs_path), start=project_folder)
+        except ValueError:
+            # On Windows, when path and start are on different drives.
+            rel_path = os.path.normpath(abs_path)
+        return rel_path
 
     def toolButtonImport(self):
         directory_path = QFileDialog.getExistingDirectory(
@@ -324,7 +336,8 @@ class ImportPhotos:
 
         if directory_path:
             self.selected_folder = directory_path[:]
-            self.selected_folder = './' + os.path.basename(os.path.normpath(self.selected_folder)) + '/'
+            self.selected_folder = self.get_path_relative_to_project_root(
+                self.selected_folder)
             self.dlg.imp.setText(directory_path)
 
     def import_photos(self):
@@ -537,7 +550,8 @@ class ImportPhotos:
             picture_paths.append(os.path.basename(feature.attribute("Path")))
 
         # Pictures that should be removed from the layer
-        self.selected_folder = './' + os.path.basename(os.path.normpath(base_picture_directory)) + '/'
+        self.selected_folder = self.get_path_relative_to_project_root(
+            base_picture_directory)
         list_pictures = []
         try:
             for root, dirs, files in os.walk(base_picture_directory):
@@ -613,7 +627,8 @@ class ImportPhotos:
 
     def get_geo_infos_from_photo(self, photo_path):
         try:
-            rel_path = self.selected_folder + os.path.basename(photo_path)
+            rel_path = os.path.join(
+                self.selected_folder, os.path.basename(photo_path))
             ImagesSrc = '<img src = "' + rel_path + '" width="300" height="225"/>'
             if CHECK_MODULE == 'exifread':
                 with open(photo_path, 'rb') as imgpathF:

--- a/code/MouseClick.py
+++ b/code/MouseClick.py
@@ -98,11 +98,11 @@ class MouseClick(QgsMapTool):
                     else:
                         return
 
+                    self.drawSelf.prj = QgsProject.instance()
                     try:
                         if not os.path.exists(imPath):
-                            self.prj = QgsProject.instance()
-                            if self.prj.fileName() and 'RELPATH' in fields:
-                                imPath = os.path.join(QFileInfo(self.prj.fileName()).absolutePath(),
+                            if self.drawSelf.prj.fileName() and 'RELPATH' in fields:
+                                imPath = os.path.join(QFileInfo(self.drawSelf.prj.fileName()).absolutePath(),
                                                       feature.attributes()[feature.fieldNameIndex('RelPath')])
                             else:
                                 c = self.drawSelf.noImageFound()

--- a/code/PhotosViewer.py
+++ b/code/PhotosViewer.py
@@ -214,8 +214,9 @@ class PhotoWindow(QWidget):
             if not os.path.exists(imPath):
                 try:
                     if self.drawSelf.prj.fileName() and 'RELPATH' in self.drawSelf.fields:
-                        imPath = QFileInfo(self.drawSelf.prj.fileName()).absolutePath() + \
-                                 attributes[f.fieldNameIndex('RelPath')]
+                        imPath = os.path.join(
+                            QFileInfo(self.drawSelf.prj.fileName()).absolutePath(),
+                            attributes[f.fieldNameIndex('RelPath')])
                 except:
                     imPath = ''
             try:


### PR DESCRIPTION
Loading photos using relative paths (RelPath) in PhotoWindow did not work in plugin version 3.0.5 (and the latest master branch). It crashed with the following error when switching photos by clicking the left/right arrow icons or when pressing the left/right arrow keys:

```
File "/home/user/.local/share/QGIS/QGIS3/profiles/default/python/plugins/ImportPhotos/code/PhotosViewer.py", line 603, in updateWindow
              c = self.drawSelf.noImageFound()
             AttributeError: 'ImportPhotos' object has no attribute 'noImageFound'

During handling of the above exception, another exception occurred:
             
Traceback (most recent call last):
File "/home/user/.local/share/QGIS/QGIS3/profiles/default/python/plugins/ImportPhotos/code/PhotosViewer.py", line 145, in keyPressEvent
self.selfwindow.leftClickButton()
File "/home/user/.local/share/QGIS/QGIS3/profiles/default/python/plugins/ImportPhotos/code/PhotosViewer.py", line 588, in leftClickButton
self.updateWindow()
File "/home/user/.local/share/QGIS/QGIS3/profiles/default/python/plugins/ImportPhotos/code/PhotosViewer.py", line 606, in updateWindow
c = self.drawSelf.noImageFound()
AttributeError: 'ImportPhotos' object has no attribute 'noImageFound'
```

This pull request fixes the bug by:

- Using os.path.join instead of string concatenation to obtain the absolute image path from the project directory and RelPath.
- Assigning the QgsProject instance to drawSelf.prj in MouseClick, so that it is always available in PhotoWindow as well.

(Please note that this pull request does not attempt to address the fact that the ```drawSelf.noImageFound``` function is not defined anywhere in the codebase.)