### PR TITLE
Update maximum QGIS version to 4.99

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -9,7 +9,7 @@
 [general]
 name=ImportPhotos
 qgisMinimumVersion=2.99
-qgisMaximumVersion=3.99
+qgisMaximumVersion=4.99
 description=Import Photos
 version=3.0.8
 author=Marios S. Kyriakou, George A. Christou, Panayiotis S. Kolios, Demetris G. Eliades, KIOS Research and Innovation Center of Excellence (KIOS CoE)


### PR DESCRIPTION
Allow plugin to be installed in QGIS 4.XX versions